### PR TITLE
Documentation to migrate from Rococo

### DIFF
--- a/.github/ISSUE_TEMPLATE/migrate-rococo-pase.yml
+++ b/.github/ISSUE_TEMPLATE/migrate-rococo-pase.yml
@@ -10,22 +10,22 @@ body:
     attributes:
       value: |
         ### Your parachain collators need to be stopped before openning this issue!
-  - type: input
-    id: roc_para_id
-    attributes:
-      label: Para Id in Rococo
-      description: "The Id of the parachain to be migrated from Rococo"
-      placeholder: "Example: 2000"
-    validations:
-      required: true
-  - type: input
-    id: manager_account
-    attributes:
-      label: Parachain Manager Account
-      description: "Using the same account than in Rococo is recommended. It will be retrieved from Rococo if not provided here."
-      placeholder: "Example:5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
-    validations:
-      required: false
+- type: input
+  id: roc_para_id
+  attributes:
+    label: Para Id in Rococo
+    description: "The Id of the parachain to be migrated from Rococo"
+    placeholder: "Example: 2000"
+  validations:
+    required: true
+- type: input
+  id: manager_account
+  attributes:
+    label: Parachain Manager Account
+    description: "Using the same account than in Rococo is recommended. It will be retrieved from Rococo if not provided here."
+    placeholder: "Example:5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+  validations:
+    required: false
 - type: input
     id: poo
     attributes:

--- a/.github/ISSUE_TEMPLATE/migrate-rococo-pase.yml
+++ b/.github/ISSUE_TEMPLATE/migrate-rococo-pase.yml
@@ -4,7 +4,8 @@ labels: [RocMigration]
 assignees:
   - al3mart
   - hbulgarini
-  - jleni 
+  - 
+educlerici-zondax  
 body:
 - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/migrate-rococo-pase.yml
+++ b/.github/ISSUE_TEMPLATE/migrate-rococo-pase.yml
@@ -1,0 +1,36 @@
+name: Migrate parachain from Rococo to Paseo
+description: "Use this issue template to migrate a parachain from Rococo to Paseo"
+labels: [RocMigration]
+assignees:
+  - al3mart
+  - hbulgarini
+  - jleni 
+body:
+- type: markdown
+    attributes:
+      value: |
+        ### Your parachain collators need to be stopped before openning this issue!
+  - type: input
+    id: roc_para_id
+    attributes:
+      label: Para Id in Rococo
+      description: "The Id of the parachain to be migrated from Rococo"
+      placeholder: "Example: 2000"
+    validations:
+      required: true
+  - type: input
+    id: manager_account
+    attributes:
+      label: Parachain Manager Account
+      description: "Using the same account than in Rococo is recommended. It will be retrieved from Rococo if not provided here."
+      placeholder: "Example:5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+    validations:
+      required: false
+- type: input
+    id: poo
+    attributes:
+      label: Proof of Ownership
+      description: "As means of proving owernership of said account, please sign the message `PASEO` with it. Instructions can be found [here](../../docs/rococo_migration.md). This is not mandatory."
+      placeholder: "0x1234...ABCD"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/migrate-rococo-pase.yml
+++ b/.github/ISSUE_TEMPLATE/migrate-rococo-pase.yml
@@ -4,8 +4,7 @@ labels: [RocMigration]
 assignees:
   - al3mart
   - hbulgarini
-  - 
-educlerici-zondax  
+  - educlerici-zondax  
 body:
 - type: markdown
     attributes:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
-# support
-Support tasks for Paseo network
+# Paseo Network support repository
+
+
+
+### 🧳 Migrate your parachain from Rococo to Paseo
+
+If you are the maintainer of a parachain running on Rococo and you are looking 
+to keep your parachain running in Paseo, please go ahead and follow the migration guide: 
+
+- [Migrate parachain from Rococo to Paseo](docs/rococo_migration.md)

--- a/docs/rococo_migration.md
+++ b/docs/rococo_migration.md
@@ -18,7 +18,8 @@ The migration process is rather simple. One just needs to open an issue here:
 
 In the issue tempalate there is space to fill the following information:
 
-**ParaId**
+### **ParaId**
+
 The Id of the parachain running in Rococo we want to migrate. This Id will be used to
 retrieve the following data:
 - `paras.heads(ParaId)` 
@@ -26,8 +27,40 @@ retrieve the following data:
 for this parachain.
 - `registrar.paras(ParaId)` from this struct the current manager account will be extrancted.
 
-**Manager Account**
+And will be the Id used to register the new parachain in Paseo. Avoiding innecessary changes in the parachain codebase.
+
+### **Manager Account**
+
 Ideally the same account than in Rococo will be used as a way of streamlining the process.
 
-**Proof of Ownership**
-As a way
+### **Proof of Ownership**
+
+As a way of proving that the creator of the issue has access to the manager account. This proof could be requested if the reviewers can't identify the user making the request.
+
+In order to generate such proof, use the `sign` subcommand that ships with substrate. A bianry that contains such subcommand is for isntance `staging-node-cli` in [`polkadot-sdk/substrate/bin/node`](https://github.com/paritytech/polkadot-sdk/tree/master/substrate/bin/node).
+Which can be built like this:
+```bash
+$ cargo build --release -p staging-node-cli
+```
+> Bear in mind that the resulting binary is called `substrate-node`
+
+Once the binary with this subcommand is ready the message to sing is `PASEO`. Which can be achieved running:
+```bash
+./substrate-node sign --message PASEO --suri <secret>
+```
+> Note that there are various options of providing the secret, pelase check the output of `sing --help`.
+
+The output of the execution shoul be something similar to 
+`0xbaa49812c9ddd70bb8514ba3841a25a8117c2c33cedde5229e4e1f058ce24f57281c45afb10c1dc094d2c3438cdc61884a9a814cd34358a41b017e3755734b8a` 
+
+_(In my tests I have been observing the output including a character `%` at the end of the signature, which is not part of it.)_
+
+---
+
+Once done you should see that your parachain is being registered and ready to start onboarding.
+
+The final step would be running the collators again pointing to the right chain specs.
+
+Paseo's raw spec can be found at:
+- [paseo-network/runtimes/chain-specs](https://github.com/paseo-network/runtimes/tree/main/chain-specs)
+- [polkadot-sdk/polkadot/node/service/chain-specs](https://github.com/paritytech/polkadot-sdk/tree/master/polkadot/node/service/chain-specs)

--- a/docs/rococo_migration.md
+++ b/docs/rococo_migration.md
@@ -37,7 +37,7 @@ Ideally the same account than in Rococo will be used as a way of streamlining th
 
 As a way of proving that the creator of the issue has access to the manager account. This proof could be requested if the reviewers can't identify the user making the request.
 Note this can be done in various way, for instance, using polkadot.js/apps - https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frococo-rpc.polkadot.io#/signing
-In order to generate such proof, use the `sign` subcommand that ships with substrate. A bianry that contains such subcommand is for isntance `staging-node-cli` in [`polkadot-sdk/substrate/bin/node`](https://github.com/paritytech/polkadot-sdk/tree/master/substrate/bin/node).
+Another way to generate such proof: use the `sign` subcommand that ships with substrate. A bianry that contains such subcommand is for isntance `staging-node-cli` in [`polkadot-sdk/substrate/bin/node`](https://github.com/paritytech/polkadot-sdk/tree/master/substrate/bin/node).
 Which can be built like this:
 ```bash
 $ cargo build --release -p staging-node-cli

--- a/docs/rococo_migration.md
+++ b/docs/rococo_migration.md
@@ -14,7 +14,7 @@ Once all your machines are not executing your parachain binaries, then it is saf
 
 The migration process is rather simple. One just needs to open an issue here:
 
-- [Migration Issue]()
+- [Migration Issue](https://github.com/paseo-network/support/issues/new/choose)
 
 In the issue tempalate there is space to fill the following information:
 

--- a/docs/rococo_migration.md
+++ b/docs/rococo_migration.md
@@ -36,7 +36,7 @@ Ideally the same account than in Rococo will be used as a way of streamlining th
 ### **Proof of Ownership**
 
 As a way of proving that the creator of the issue has access to the manager account. This proof could be requested if the reviewers can't identify the user making the request.
-
+Note this can be done in various way, for instance, using polkadot.js/apps - https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frococo-rpc.polkadot.io#/signing
 In order to generate such proof, use the `sign` subcommand that ships with substrate. A bianry that contains such subcommand is for isntance `staging-node-cli` in [`polkadot-sdk/substrate/bin/node`](https://github.com/paritytech/polkadot-sdk/tree/master/substrate/bin/node).
 Which can be built like this:
 ```bash

--- a/docs/rococo_migration.md
+++ b/docs/rococo_migration.md
@@ -37,6 +37,7 @@ Ideally the same account than in Rococo will be used as a way of streamlining th
 
 As a way of proving that the creator of the issue has access to the manager account. This proof could be requested if the reviewers can't identify the user making the request.
 Note this can be done in various way, for instance, using polkadot.js/apps - https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frococo-rpc.polkadot.io#/signing
+
 Another way to generate such proof: use the `sign` subcommand that ships with substrate. A bianry that contains such subcommand is for isntance `staging-node-cli` in [`polkadot-sdk/substrate/bin/node`](https://github.com/paritytech/polkadot-sdk/tree/master/substrate/bin/node).
 Which can be built like this:
 ```bash

--- a/docs/rococo_migration.md
+++ b/docs/rococo_migration.md
@@ -1,0 +1,33 @@
+# Migrate a parachain from Rococo to Paseo
+
+The migration process that is done in this guide is a hard spoon. Meaning that
+the current state and code from the running network will be taken and used as
+genesis for the parachain being registered in Paseo.
+
+If this process is not of your interest, please continue with a usual parachain
+onboarding.
+
+---
+
+The very first step before initiating the migration would be stopping all the collators.
+Once all your machines are not executing your parachain binaries, then it is safe to proceed.
+
+The migration process is rather simple. One just needs to open an issue here:
+
+- [Migration Issue]()
+
+In the issue tempalate there is space to fill the following information:
+
+**ParaId**
+The Id of the parachain running in Rococo we want to migrate. This Id will be used to
+retrieve the following data:
+- `paras.heads(ParaId)` 
+- `paras.currentCodeHash(ParaId)` which at the same time will be used to retrieve the actual code
+for this parachain.
+- `registrar.paras(ParaId)` from this struct the current manager account will be extrancted.
+
+**Manager Account**
+Ideally the same account than in Rococo will be used as a way of streamlining the process.
+
+**Proof of Ownership**
+As a way

--- a/docs/rococo_migration.md
+++ b/docs/rococo_migration.md
@@ -48,7 +48,7 @@ Once the binary with this subcommand is ready the message to sing is `PASEO`. Wh
 ```bash
 ./substrate-node sign --message PASEO --suri <secret>
 ```
-> Note that there are various options of providing the secret, pelase check the output of `sing --help`.
+> Note that there are various options of providing the secret, pelase check the output of `sign --help`.
 
 The output of the execution shoul be something similar to 
 `0xbaa49812c9ddd70bb8514ba3841a25a8117c2c33cedde5229e4e1f058ce24f57281c45afb10c1dc094d2c3438cdc61884a9a814cd34358a41b017e3755734b8a` 
@@ -59,7 +59,9 @@ _(In my tests I have been observing the output including a character `%` at the 
 
 Once done you should see that your parachain is being registered and ready to start onboarding.
 
-The final step would be running the collators again pointing to the right chain specs.
+Be mindful of your "old" parachain's database, you might want to back it up or you might choose to simply purge it. But this could be a good moment to address it.
+
+Now everything should be ready to run the collators again pointing now to the right chain specs.
 
 Paseo's raw spec can be found at:
 - [paseo-network/runtimes/chain-specs](https://github.com/paseo-network/runtimes/tree/main/chain-specs)


### PR DESCRIPTION
Initial documentation to migrate a parachain from Rococo to Paseo.

The logic for the migration is not present in at this stage in the MR as the logic uses SUDO, and I would prefer to wait for some reviews before pushing it.