### PR TITLE
 document runtime upgrade process

### DIFF
--- a/documents/doc_runtime_upgrade_communication_template.md
+++ b/documents/doc_runtime_upgrade_communication_template.md
@@ -1,0 +1,65 @@
+# Paseo Communication Template to use for the Runtime Upgrade Process
+
+## Pre-Upgrade Announcement
+
+> **Upcoming Runtime Upgrade for Paseo Testnet**
+> 
+> Hello Paseo Community,
+> We're excited to announce a planned runtime upgrade for the Paseo Testnet, scheduled for [Date]. This upgrade will introduce [briefly describe main features/improvements] to enhance our network's performance and security.
+>
+> What This Means for You:
+> - Validators: Please prepare for the upgrade by [specific actions for validators].
+> - - Developers: Test your applications against the upgrade on our test environment by [details].
+>   - - Users: No action is needed from you at this stage.
+>
+>  Timeline:
+> - Upgrade Announcement: Today
+> - Final Testing Phase: [Date]
+> - Upgrade Execution: [Date]
+>     
+> Stay tuned for more updates as we approach the upgrade date. We appreciate your support and participation in making the Paseo Testnet better.
+>
+> Best,
+>
+> The Paseo Testnet Team
+
+
+## Upgrade Reminder
+> **Reminder: Paseo Testnet Upgrade Happening on [Date]**
+>
+> Hello Paseo Community,
+>
+> This is a friendly reminder that the Paseo Testnet will undergo a runtime upgrade on [Date]. We encourage all validators and developers to make the necessary preparations if you haven't done so already.
+>
+> Quick Checklist:
+>
+> - Validators: [Reminder of actions for validators].
+> - Developers: Ensure compatibility with the new runtime by [date].
+> 
+> For detailed instructions and more information about the upgrade, please refer to [link].
+>
+> Thank you for your cooperation and for being an essential part of the Paseo community.
+>
+> Best,
+>
+> The Paseo Testnet Team
+
+## Post-Upgrade Update
+> **Paseo Testnet Upgrade Successfully Completed**
+>
+> Hello Paseo Community,
+>
+> We're pleased to announce that the Paseo Testnet has been successfully upgraded as of [Date]. Thanks to your cooperation and support, the process went smoothly, and we're already seeing positive impacts, including [briefly highlight outcomes].
+>
+> What's Next:
+> - Validators: Please ensure your nodes are running smoothly on the new version.
+> - Developers: Check out the updated documentation [link] to take full advantage of the new features.
+> - Users: Enjoy the enhanced performance and security of the Paseo Testnet.
+> 
+> Should you encounter any issues or have questions, please don't hesitate to reach out on Paseo Testnet Support Element channel or Create an issue on the Support Repository.
+>
+> Thank you for being a vital part of this upgrade. Your ongoing support and participation drive the success of the Paseo Testnet.
+>
+> Best,
+>
+> The Paseo Testnet Team

--- a/documents/doc_runtime_upgrade_process.md
+++ b/documents/doc_runtime_upgrade_process.md
@@ -45,6 +45,6 @@ This process covers all steps from the initial planning and scheduling of a runt
 Include common issues that might arise during the upgrade process and their solutions. Provide contact information for real-time assistance.
 
 ## Appendix
-A.1 Upgrade Proposal Template: Outline the structure for upgrade proposals.
-A.2 Communication Template: Sample messages for informing the community about the upgrade phases.
-A.3 Checklist for Validators: Pre and post-upgrade checklist for validators.
+- A.1 Upgrade Proposal Template: Outline the structure for upgrade proposals.
+- A.2 Communication Template: Sample messages for informing the community about the upgrade phases.
+- A.3 Checklist for Validators: Pre and post-upgrade checklist for validators.

--- a/documents/doc_runtime_upgrade_process.md
+++ b/documents/doc_runtime_upgrade_process.md
@@ -1,0 +1,50 @@
+# Runtime Upgrade Process for Paseo
+## Purpose
+This document outlines the standardized procedure for conducting a runtime upgrade on the Paseo Testnet. It aims to ensure that upgrades are executed smoothly, securely, and with minimal network disruption.
+
+## Scope
+This process covers all steps from the initial planning and scheduling of a runtime upgrade to its final deployment and post-deployment monitoring on the Paseo Testnet.
+
+## Prerequisites
+- Access to the Paseo Testnet repository with necessary permissions.
+- A tested and reviewed runtime upgrade proposal.
+- Approval from the Paseo governance body or a consensus among the core development team, as per the governance model.
+
+## Process Overview
+### Preparation
+
+1.1 Proposal Review: Ensure the runtime upgrade has been thoroughly reviewed and tested. This includes peer review of the code changes and testing in a controlled environment.
+1.2 Communication Plan: Prepare a communication plan to inform validators, developers, and users about the upcoming upgrade, including timelines and expected actions.
+
+*TO-DO:WORK ON THE COMMUNICATION PLAN*
+
+### Scheduling
+2.1 Determine Upgrade Window: Choose a time for the upgrade that minimizes impact on network users. Consider different time zones and network activity patterns.
+2.2 Notify Stakeholders: Use the communication plan to notify all stakeholders of the scheduled upgrade time. Provide detailed instructions for validators and users, if any actions on their part are required.
+
+### Execution
+3.1 Final Checks: Perform last-minute checks and ensure all stakeholders are prepared for the upgrade.
+3.2 Deploy Upgrade: Execute the runtime upgrade using the agreed-upon method (e.g., Sudo, Democracy proposal, or other governance mechanisms).
+3.3 Monitor Deployment: Closely monitor the network for any unexpected behavior as the upgrade takes effect.
+
+### Validation
+4.1 Verify Upgrade Success: Confirm that the new runtime is operating as expected. Check block production, transaction processing, and other critical network functions.
+4.2 Stakeholder Feedback: Gather feedback from validators, developers, and users to ensure the upgrade has not introduced any unforeseen issues.
+
+### Post-Deployment
+5.1 Update Documentation: Ensure all relevant documentation is updated to reflect the new runtime features or changes.
+5.2 Communicate Completion: Inform all stakeholders that the upgrade has been successfully completed and the network is stable.
+5.3 Review Process: Conduct a post-upgrade review to identify any issues or improvements for future upgrades.
+
+## Roles and Responsibilities
+- Core Developers: Prepare the runtime upgrade, perform testing, and assist in troubleshooting post-upgrade issues.
+- Validators: Update their nodes as required and monitor the network's stability.
+- Communication Team: Inform the community about the upgrade schedule, requirements, and status updates.
+
+## Troubleshooting
+Include common issues that might arise during the upgrade process and their solutions. Provide contact information for real-time assistance.
+
+## Appendix
+A.1 Upgrade Proposal Template: Outline the structure for upgrade proposals.
+A.2 Communication Template: Sample messages for informing the community about the upgrade phases.
+A.3 Checklist for Validators: Pre and post-upgrade checklist for validators.

--- a/documents/doc_runtime_upgrade_template.md
+++ b/documents/doc_runtime_upgrade_template.md
@@ -1,0 +1,47 @@
+# Paseo Runtime Upgrade Proposal Template
+
+## Proposal Metadata
+- Proposal Title:
+- Proposal ID/Version: [Unique identifier for tracking and discussion]
+- Author(s):
+- Submission Date:
+- Target Upgrade Date:
+
+## Summary
+Provide a brief overview of the upgrade proposal, including the main objectives and the expected outcomes.
+
+## Rationale
+Explain the reasoning behind this upgrade. Include the problems or limitations addressed by this upgrade, potential benefits, and why this upgrade is necessary for the Paseo Testnet at this time.
+
+## Technical Details
+### Upgrade Overview
+- Affected Components: List the components of the testnet that will be affected by this upgrade.
+- New Features: Describe any new features that will be introduced with this upgrade.
+- Improvements: Outline the improvements over the current version.
+
+### Implementation
+- Technical Specifications: Provide detailed technical specifications of the proposed upgrade, including any new parameters or changes to existing configurations.
+- Code Changes: Link to the pull request(s) or commit(s) in the repository that contain the proposed code changes.
+- Testing: Summarize the testing that has been conducted to ensure the upgrade functions as expected. *PROPOSAL: Include test results and how they were obtained.*
+
+## Impact Analysis
+- Network Performance: Discuss how the upgrade will impact network performance, including any potential downtime or disruptions.
+- Security Considerations: Address any security implications of the upgrade. Highlight any new security features or changes to existing security mechanisms.
+- Compatibility: Explain how the upgrade will affect existing operations, including backward compatibility and interactions with other components or protocols.
+
+## Rollout Plan
+- Deployment Steps: Outline the steps to deploy the upgrade, including any scripts or commands to be executed.
+- Monitoring and Validation: Describe the plan for monitoring the upgrade process and validating the outcome once the upgrade is live.
+- Fallback Plan: Provide a contingency plan in case the upgrade encounters issues or needs to be rolled back.
+
+## Stakeholder Considerations
+- Validator Actions: Detail any actions required from validators before, during, or after the upgrade.
+- User Impact: Discuss how users will be affected and whether they need to take any action as a result of the upgrade.
+
+## Communication Plan
+Outline how and when stakeholders will be informed about the upgrade process, including timelines for announcements, updates, and post-upgrade reviews.
+*TODO: COMMUNICATION PLAN PROPOSAL*
+
+## TODO PROPOSALS: Appendices
+- A. Test Results: Attach or link to detailed test results supporting the upgrade proposal.
+- B. Additional References: Provide any additional documents, links, or references relevant to the proposal.

--- a/documents/doc_runtime_upgrade_validators_checklist.md
+++ b/documents/doc_runtime_upgrade_validators_checklist.md
@@ -1,0 +1,36 @@
+# Pre-Upgrade Checklist for Validators
+
+## Preparation:
+- [ ] Review Upgrade Announcement: Understand the scope, features, and timeline of the upcoming runtime upgrade.
+- [ ] Check Compatibility: Ensure your node software is compatible with the upgrade. Update any necessary components as advised in the upgrade announcement.
+- [ ] Backup Data: Back up your node’s data, including the blockchain database and keys, to prevent any potential loss during the upgrade process.
+
+## Testing:
+- [ ] Participate in Testnet: If available, join the testnet or staging environment to test the new runtime and identify any issues with your setup. *TODO: TO VALIDATE WITH DEV TEAM.*
+- [ ] Validate Configuration Changes: Apply and test any configuration changes required by the new runtime on the testnet.
+
+## Communication:
+- [ ] Stay Informed: Follow official channels for any last-minute updates or instructions regarding the upgrade.
+- [ ] Coordinate with Other Validators: Engage with the validator community to share insights, tips, and best practices for the upgrade.
+
+# Post-Upgrade Checklist for Validators
+## Verification:
+- [ ] Confirm Node Upgrade: Verify that your node is running the correct version of the software post-upgrade.
+- [ ] Check Network Connectivity: Ensure your node has reconnected to the network and is in sync with the blockchain.
+- [ ] Monitor Validator Performance: Keep an eye on block production and validation performance to ensure your node operates as expected.
+
+## Security Checks:
+- [ ] Validate Key Security: Confirm that validator keys are secure and operational.
+- [ ] Audit for Anomalies: Check logs for any unusual activity or errors that could indicate problems with the node or its security.
+
+## Engagement:
+- [ ] Report Issues: If you encounter any problems, report them to the development team or through the appropriate community support channels.
+- [ ] Share Feedback: Provide feedback on the upgrade process, including any challenges faced or suggestions for improvement.
+
+## Maintenance:
+- [ ] Update Monitoring Tools: If the upgrade includes changes that affect monitoring or alerting, update your tools and settings accordingly.
+- [ ] Review Documentation: Check for any updates to validator documentation post-upgrade and adjust your operations as necessary.
+
+## Community Participation:
+- [ ] Contribute to Post-Upgrade Review: Participate in discussions about the upgrade's success and areas for improvement.
+- [ ] Support Other Validators: Help other community members who may have questions or face issues with the upgrade.


### PR DESCRIPTION
I've created 4 docs for this process:

- doc_runtime_upgrade_communication_template.md: Communication template to be used for the Management team to communicate about the Runtime Upgrade Process.
- doc_runtime_upgrade_process.md: Document to explain about the hole Runtime Upgrade Process
- doc_runtime_upgrade_template.md: Template to use when a new Runtime Upgrade needs to be presented.
- doc_runtime_upgrade_validators_checklist.md: Checklist to use for validators after Runtime Upgrade.

TO-DO:
- Link documents between them
- Review technical concepts if they apply to Paseo process.
- Solve TO-DOs comments in markdown files.